### PR TITLE
add default values for dask chunk processing

### DIFF
--- a/coeusai_dialog.py
+++ b/coeusai_dialog.py
@@ -29,6 +29,10 @@ WIDGET_WIDTH = 600  # Width of all the widgets
 WIDGET_HEIGHT = 20  # Height of all non-label widgets
 HELP_ICON_SIZE = 12  # Size of the help icon
 
+# Dask constants
+CHUNK_SIZE = 1000  # Default chunk size
+CHUNK_OVERLAP = 100  # Default chunk overlap size
+
 # Get current folder
 cmd_folder = os.path.split(inspect.getfile(inspect.currentframe()))[0]
 
@@ -287,7 +291,7 @@ class CoeusAIDialog(QtWidgets.QDialog):
         chunk_size_label_layout.setAlignment(QtCore.Qt.AlignLeft)
         self.chunk_size_spinbox = QtWidgets.QSpinBox()
         self.chunk_size_spinbox.setRange(500, 10000)
-        self.chunk_size_spinbox.setValue(100)
+        self.chunk_size_spinbox.setValue(CHUNK_SIZE)
         self.chunk_size_spinbox.setStyleSheet(f"font-size: {FONTSIZE}px;")
         self.advanced_layout.addLayout(chunk_size_label_layout)
         self.advanced_layout.addWidget(self.chunk_size_spinbox)
@@ -304,7 +308,7 @@ class CoeusAIDialog(QtWidgets.QDialog):
         overlap_size_label_layout.setAlignment(QtCore.Qt.AlignLeft)
         self.overlap_size_spinbox = QtWidgets.QSpinBox()
         self.overlap_size_spinbox.setRange(0, 1000)
-        self.overlap_size_spinbox.setValue(25)
+        self.overlap_size_spinbox.setValue(CHUNK_OVERLAP)
         self.overlap_size_spinbox.setStyleSheet(f"font-size: {FONTSIZE}px;")
         self.advanced_layout.addLayout(overlap_size_label_layout)
         self.advanced_layout.addWidget(self.overlap_size_spinbox)
@@ -359,14 +363,20 @@ class CoeusAIDialog(QtWidgets.QDialog):
         self.logger.info(f"Compute Mode: {compute_mode}")
 
         # Get chunk size and overlap size
-        if self.advanced_group_box.isChecked():
-            chunk_size = self.chunk_size_spinbox.value()
-            overlap_size = self.overlap_size_spinbox.value()
+        if compute_mode != "normal":
+            # Default values if advanced options are not checked
+            chunk_size = CHUNK_SIZE
+            overlap_size = CHUNK_OVERLAP
+            # User defined values if advanced options are checked
+            if self.advanced_group_box.isChecked():
+                chunk_size = self.chunk_size_spinbox.value()
+                overlap_size = self.overlap_size_spinbox.value()
             self.logger.info(f"Chunk Size: {chunk_size}")
-            self.logger.info(f"Overlap Size: {overlap_size}")
+            self.logger.info(f"Overlap Size: {overlap_size}")      
         else:
             chunk_size = None
             overlap_size = None
+            
 
         prediction_tif = read_input_and_labels_and_save_predictions(
             raster_path,

--- a/coeusai_dialog.py
+++ b/coeusai_dialog.py
@@ -372,7 +372,7 @@ class CoeusAIDialog(QtWidgets.QDialog):
                 chunk_size = self.chunk_size_spinbox.value()
                 overlap_size = self.overlap_size_spinbox.value()
             self.logger.info(f"Chunk Size: {chunk_size}")
-            self.logger.info(f"Overlap Size: {overlap_size}")      
+            self.logger.info(f"Overlap Size: {overlap_size}")
         else:
             chunk_size = None
             overlap_size = None

--- a/coeusai_dialog.py
+++ b/coeusai_dialog.py
@@ -376,7 +376,6 @@ class CoeusAIDialog(QtWidgets.QDialog):
         else:
             chunk_size = None
             overlap_size = None
-            
 
         prediction_tif = read_input_and_labels_and_save_predictions(
             raster_path,

--- a/coeusai_dialog.py
+++ b/coeusai_dialog.py
@@ -364,13 +364,8 @@ class CoeusAIDialog(QtWidgets.QDialog):
 
         # Get chunk size and overlap size
         if compute_mode != "normal":
-            # Default values if advanced options are not checked
-            chunk_size = CHUNK_SIZE
-            overlap_size = CHUNK_OVERLAP
-            # User defined values if advanced options are checked
-            if self.advanced_group_box.isChecked():
-                chunk_size = self.chunk_size_spinbox.value()
-                overlap_size = self.overlap_size_spinbox.value()
+            chunk_size = self.chunk_size_spinbox.value()
+            overlap_size = self.overlap_size_spinbox.value()
             self.logger.info(f"Chunk Size: {chunk_size}")
             self.logger.info(f"Overlap Size: {overlap_size}")
         else:


### PR DESCRIPTION
fix #46. Introduces the defult chunksize and overlap sizes for dask processing. In case users did not check the "advanced options", "parallel" and "safe" mode can still be used for large data.